### PR TITLE
Change link to go to project rather than image view

### DIFF
--- a/_includes/js/item-js.html
+++ b/_includes/js/item-js.html
@@ -21,10 +21,11 @@
         /* add object */ 
         var format = record.format;
         var objectLink = '{{ "/objects/" | absolute_url }}' + record.filename;
+        var projectLink = record.link;
         var itemImage, itemLink;
         if (format.includes('image')) {
-            itemImage= '<div class="gallery-img" data-src="' + objectLink + '"><img class="img-fluid" src="' + objectLink + '" alt="' + objectTitle + '"><p><small>Click to view full screen</small></p></div>';
-            itemLink= '<a href="' + objectLink + '" target="_blank" class="btn btn-dark" title="Object download">Download Image</a>';
+            itemImage= '<div><a href="' + projectLink + '" target="_blank" class="btn" title="Link to '+ record.title +'"><img class="img-fluid" src="' + objectLink + '" alt="' + objectTitle + '"></div>';
+            itemLink= '<a href="' + projectLink + '" target="_blank" class="btn btn-dark" title="Link to '+ record.title +'">Go to Project</a>';
         } else if (format.includes('application')) {
             itemImage= '<object data="' + objectLink + '" type="application/pdf" width="100%" height="450px"><p>The PDF is not rendering in your browser. Please use the button below to download the PDF.</p></object>';
             itemLink= '<a href="' + objectLink + '" target="_blank" class="btn btn-dark" title="Object download">Download PDF</a>';


### PR DESCRIPTION
Hi @brockdsl in response to #1 and based off work I just did for @SharonJanzen on the geo-data listings project, this PR changes the function and wording of the image and button on the item page so that clicking either will take you to a new tab that features the related project. 

Thank you for using CollectionBuilder and please let us know if we can be of any more assistance. I know this may be way past when this was necessary but hopefully it's of some use. 

And we will be working on including this type of use case in future versions of CollectionBuilder. Cheers! Devin